### PR TITLE
Add version regex check

### DIFF
--- a/python/tests/test_version.py
+++ b/python/tests/test_version.py
@@ -1,5 +1,6 @@
 # python/tests/test_version.py
 
+import re
 import pyfastlanes
 
 def test_get_version():
@@ -7,3 +8,4 @@ def test_get_version():
     print("-- version : {}".format(version))
     assert isinstance(version, str)
     assert len(version) > 0
+    assert re.match(r'^\d+\.\d+\.\d+', version)


### PR DESCRIPTION
## Summary
- verify that `get_version` matches a semantic version pattern

## Testing
- `pytest python/tests -q` *(fails: ModuleNotFoundError: No module named 'pyfastlanes')*

------
https://chatgpt.com/codex/tasks/task_e_6840b679df80832797bcbfb6bbc8519b