### PR TITLE
Fix typo in CSV parser docs

### DIFF
--- a/rust/vendor/fastlanes/include/fls/csv/csv-parser/parser.hpp
+++ b/rust/vendor/fastlanes/include/fls/csv/csv-parser/parser.hpp
@@ -123,8 +123,8 @@ public:
 		return m_state == State::EMPTY;
 	}
 
-        // Not the actual position in the stream (its buffered) just the
-        // position up to last available token
+	// Not the actual position in the stream (its buffered) just the
+	// position up to last availiable token
 	std::streamoff position() const {
 		return m_scanposition + static_cast<std::streamoff>(m_cursor);
 	}

--- a/rust/vendor/fastlanes/include/fls/csv/csv-parser/parser.hpp
+++ b/rust/vendor/fastlanes/include/fls/csv/csv-parser/parser.hpp
@@ -123,8 +123,8 @@ public:
 		return m_state == State::EMPTY;
 	}
 
-	// Not the actual position in the stream (its buffered) just the
-	// position up to last availiable token
+        // Not the actual position in the stream (its buffered) just the
+        // position up to last available token
 	std::streamoff position() const {
 		return m_scanposition + static_cast<std::streamoff>(m_cursor);
 	}

--- a/src/include/fls/csv/csv-parser/parser.hpp
+++ b/src/include/fls/csv/csv-parser/parser.hpp
@@ -123,8 +123,8 @@ public:
 		return m_state == State::EMPTY;
 	}
 
-	// Not the actual position in the stream (its buffered) just the
-	// position up to last availiable token
+        // Not the actual position in the stream (its buffered) just the
+        // position up to last available token
 	std::streamoff position() const {
 		return m_scanposition + static_cast<std::streamoff>(m_cursor);
 	}


### PR DESCRIPTION
## Summary
- correct a typo in `parser.hpp` comments

## Testing
- `make format-check` *(fails: docker not found)*
- `make test_python` *(fails: cannot install dependencies due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_6840b829cd7883279cf8317a352d95e8