### PR TITLE
Fix comment for opend_app

### DIFF
--- a/rust/vendor/fastlanes/include/fls/std/filesystem.hpp
+++ b/rust/vendor/fastlanes/include/fls/std/filesystem.hpp
@@ -19,8 +19,8 @@ public:
 	static std::ofstream open_w(const path& file);
 	///! open write in binary
 	static std::ofstream open_w_binary(const path& file);
-	///! open write in binary
-	static std::ofstream opend_app(const path& file);
+        ///! open file for appending
+        static std::ofstream opend_app(const path& file);
 	///! close
 	template <typename STREAM>
 	static void close(STREAM& stream);

--- a/rust/vendor/fastlanes/include/fls/std/filesystem.hpp
+++ b/rust/vendor/fastlanes/include/fls/std/filesystem.hpp
@@ -19,8 +19,8 @@ public:
 	static std::ofstream open_w(const path& file);
 	///! open write in binary
 	static std::ofstream open_w_binary(const path& file);
-        ///! open file for appending
-        static std::ofstream opend_app(const path& file);
+	///! open file for appending
+	static std::ofstream opend_app(const path& file);
 	///! close
 	template <typename STREAM>
 	static void close(STREAM& stream);

--- a/src/include/fls/std/filesystem.hpp
+++ b/src/include/fls/std/filesystem.hpp
@@ -19,8 +19,8 @@ public:
 	static std::ofstream open_w(const path& file);
 	///! open write in binary
 	static std::ofstream open_w_binary(const path& file);
-	///! open write in binary
-	static std::ofstream opend_app(const path& file);
+        ///! open file for appending
+        static std::ofstream opend_app(const path& file);
 	///! close
 	template <typename STREAM>
 	static void close(STREAM& stream);

--- a/src/include/fls/std/filesystem.hpp
+++ b/src/include/fls/std/filesystem.hpp
@@ -19,8 +19,8 @@ public:
 	static std::ofstream open_w(const path& file);
 	///! open write in binary
 	static std::ofstream open_w_binary(const path& file);
-        ///! open file for appending
-        static std::ofstream opend_app(const path& file);
+	///! open file for appending
+	static std::ofstream opend_app(const path& file);
 	///! close
 	template <typename STREAM>
 	static void close(STREAM& stream);


### PR DESCRIPTION
## Summary
- clarify that `opend_app` opens files for appending
- mirror the comment in the vendored header

## Testing
- `cargo build --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_6840b820d4c4832795df66cc594c9b8d