### PR TITLE
Fix stp operator Get name

### DIFF
--- a/rust/vendor/fastlanes/include/fls/common/stp.hpp
+++ b/rust/vendor/fastlanes/include/fls/common/stp.hpp
@@ -178,7 +178,7 @@ stp<T>::~stp() {
 // Operator overloading.
 template <typename T, typename U>
 inline bool operator==(const stp<T>& sp1, const stp<U>& sp2) {
-	return sp1.get() == sp2.get();
+        return sp1.Get() == sp2.Get();
 }
 
 template <typename T>
@@ -188,17 +188,17 @@ inline bool operator==(const stp<T>& sp, std::nullptr_t) noexcept {
 
 template <typename T, typename U>
 inline bool operator!=(const stp<T>& sp1, const stp<U>& sp2) {
-	return sp1.get() != sp2.get();
+        return sp1.Get() != sp2.Get();
 }
 
 template <typename T>
 inline bool operator!=(const stp<T>& sp, std::nullptr_t) noexcept {
-	return sp.get();
+        return sp.Get();
 }
 
 template <typename T>
 inline bool operator!=(std::nullptr_t, const stp<T>& sp) noexcept {
-	return sp.get();
+        return sp.Get();
 }
 } // namespace fastlanes
 #endif // FLS_CMN_STP_HPP

--- a/src/include/fls/common/stp.hpp
+++ b/src/include/fls/common/stp.hpp
@@ -178,7 +178,7 @@ stp<T>::~stp() {
 // Operator overloading.
 template <typename T, typename U>
 inline bool operator==(const stp<T>& sp1, const stp<U>& sp2) {
-	return sp1.get() == sp2.get();
+        return sp1.Get() == sp2.Get();
 }
 
 template <typename T>
@@ -188,17 +188,17 @@ inline bool operator==(const stp<T>& sp, std::nullptr_t) noexcept {
 
 template <typename T, typename U>
 inline bool operator!=(const stp<T>& sp1, const stp<U>& sp2) {
-	return sp1.get() != sp2.get();
+        return sp1.Get() != sp2.Get();
 }
 
 template <typename T>
 inline bool operator!=(const stp<T>& sp, std::nullptr_t) noexcept {
-	return sp.get();
+        return sp.Get();
 }
 
 template <typename T>
 inline bool operator!=(std::nullptr_t, const stp<T>& sp) noexcept {
-	return sp.get();
+        return sp.Get();
 }
 } // namespace fastlanes
 #endif // FLS_CMN_STP_HPP


### PR DESCRIPTION
## Summary
- use `Get()` instead of `get()` for comparisons in `stp` operators

## Testing
- `g++ -std=c++17 -I./ -I./src/include -c /tmp/test.cpp`
- `g++ -std=c++17 -I./ -I./rust/vendor/fastlanes/include -c /tmp/test_vendor.cpp`


------
https://chatgpt.com/codex/tasks/task_e_6840b826f3248327abb1ea9140a69304