### PR TITLE
Fix comment typo in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# pyproject.tmol
+# pyproject.toml
 
 [build-system]
 requires = [


### PR DESCRIPTION
## Summary
- correct the file extension comment at the top of `pyproject.toml`

## Testing
- `PYTHONPATH=python pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68494ebae9e083279176678bf21b1030