### PR TITLE
Remove duplicate clang-tidy version checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,13 +228,6 @@ if (FLS_ENABLE_CLANG_TIDY)
         )
         message("-- FLS: clang-tidy version: ${CLANG_TIDY_VERSION}")
 
-        execute_process(
-                COMMAND ${CLANG_TIDY_EXE} --version
-                OUTPUT_VARIABLE CLANG_TIDY_VERSION
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        message("-- FLS: clang-tidy version: ${CLANG_TIDY_VERSION}")
-
     endif ()
 endif ()
 

--- a/rust/vendor/fastlanes/CMakeLists.txt
+++ b/rust/vendor/fastlanes/CMakeLists.txt
@@ -248,13 +248,6 @@ if (FLS_ENABLE_CLANG_TIDY)
         )
         message("-- FLS: clang-tidy version: ${CLANG_TIDY_VERSION}")
 
-        execute_process(
-                COMMAND ${CLANG_TIDY_EXE} --version
-                OUTPUT_VARIABLE CLANG_TIDY_VERSION
-                OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-        message("-- FLS: clang-tidy version: ${CLANG_TIDY_VERSION}")
-
     endif ()
 endif ()
 


### PR DESCRIPTION
## Summary
- de-duplicate clang-tidy version print in top-level CMakeLists
- remove duplicate clang-tidy version check in the vendored fastlanes CMakeLists

## Testing
- `cmake .. -DFLS_ENABLE_CLANG_TIDY=ON` (configure)
- `pytest python/tests -q` *(fails: ModuleNotFoundError: No module named 'pyfastlanes')*

------
https://chatgpt.com/codex/tasks/task_e_684af8ed23b083279ff737b8b97580cc