### PR TITLE
Fix python example cleanup

### DIFF
--- a/examples/python_example.py
+++ b/examples/python_example.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 import sys
 import os
-import subprocess
 import pyfastlanes
 
 
@@ -13,9 +12,10 @@ def main():
     # 2) Paths for the demo
     csv_dir = "../data/example"  # adjust to where your CSVs live
 
+    # 3) Clean up old output files
     if os.path.exists("data.fls"):
         os.remove("data.fls")
-    if os.path.exists("csv.fls"):
+    if os.path.exists("decoded.csv"):
         os.remove("decoded.csv")
 
     # 4) Use Connection as a context manager


### PR DESCRIPTION
## Summary
- remove unused subprocess import
- renumber comment blocks
- cleanup decoded.csv only when present

## Testing
- `PYTHONPATH=python pytest -q python/tests`

------
https://chatgpt.com/codex/tasks/task_e_684b0a334584832784882bdbb8459601