### PR TITLE
Fix trailing spaces in generator snippet

### DIFF
--- a/fls_gen/generator.py
+++ b/fls_gen/generator.py
@@ -223,7 +223,7 @@ class Generator:
         return '''
             #ifdef NDEBUG
             uint64_t iterations = 3000000;
-            #else 
+            #else
             uint64_t iterations = 1;
             #endif
                 '''


### PR DESCRIPTION
## Summary
- remove trailing spaces in `get_benchmark_iteration` snippet
- run grep check to verify there are no remaining trailing spaces

## Testing
- `grep -n "[[:blank:]]$" -n fls_gen/generator.py | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_684b5c4a46b0832784c004e4a4cefa2f