### PR TITLE
Fix README intro spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <p align="center">
   <img src="assets/logo.svg" alt="FastLanes Logo" width="360" />
 </p>
-
-
 FastLanes is like Parquet with **40% better compression** and **40× faster decoding**.
 
 ---


### PR DESCRIPTION
## Summary
- remove extra blank lines after the logo in README so the project description follows immediately

## Testing
- `None`

------
https://chatgpt.com/codex/tasks/task_e_684b5c4b120c8327a01ca3e5fdbf380a