### PR TITLE
Fix comment with google benchmark link

### DIFF
--- a/publications/data_parallelized_encodings/fls_bench/fls_bench.hpp
+++ b/publications/data_parallelized_encodings/fls_bench/fls_bench.hpp
@@ -3,7 +3,7 @@
 
 /*
  * The M1 cycle counter is from Lemire repo. https://github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/tree/master/2021/03/24
- * The other parts are from google benchmark repo, edited heavily. todo -> add the link
+ * The other parts are from google benchmark repo, edited heavily. https://github.com/google/benchmark
  */
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
## Summary
- fix the comment mentioning Google Benchmark repo by adding its link

## Testing
- `make format-check` *(fails: docker not found)*
- `pytest -q` *(fails: ModuleNotFoundError for pyfastlanes)*

------
https://chatgpt.com/codex/tasks/task_e_684b5c4ecfe883278f5f96d0cf7018f1