### PR TITLE
Fix leading blank line in logo.svg

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,5 +1,4 @@
-
-        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="3161.360284549319" 
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="3161.360284549319" 
         height="538.5399496833522" viewBox="0 0 3161.360284549319 538.5399496833522">
 			
 			<g transform="scale(8.06801422746595) translate(10, 10)">


### PR DESCRIPTION
## Summary
- trim leading blank line and whitespace from `assets/logo.svg`

## Testing
- `cargo test --quiet` *(fails: operation timed out)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyfastlanes')*

------
https://chatgpt.com/codex/tasks/task_e_684b5c4f82988327b17f0c97024797c2