### PR TITLE
Fix message typo in bitpack generator

### DIFF
--- a/fls_gen/generate_bitpack_lib.py
+++ b/fls_gen/generate_bitpack_lib.py
@@ -45,8 +45,7 @@ def generate_unpack_lib():
 def generate_bitpack_lib():
     print_success("BITPACK::UNPACK generator has been started.")
     generate_unpack_lib()
-    print_success("FINISHED!.")
-
+    print_success("FINISHED!")
 
 if __name__ == "__main__":
     generate_bitpack_lib()


### PR DESCRIPTION
## Summary
- correct the completion message in the bitpack generator script
- tidy blank lines before the main guard

## Testing
- `PYTHONPATH=python pytest python/tests/test_version.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684b5c4fd734832793b15e43656e5ab4