### PR TITLE
Fix CLEAN_SKBUILD in python.mk

### DIFF
--- a/mk/python.mk
+++ b/mk/python.mk
@@ -16,6 +16,7 @@ PROJECT_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
 # Virtual‑env and common paths (absolute)
 VENV      := $(PROJECT_ROOT)/.venv
 DIST_DIR  := $(PROJECT_ROOT)/dist
+CLEAN_SKBUILD := rm -rf $(PROJECT_ROOT)/skbuild-editable
 
 # --- venv paths differ on Windows vs. Unix ------------------
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
## Summary
- define `CLEAN_SKBUILD` so python Make targets can clean skbuild directory

## Testing
- `make -f mk/python.mk clean-python`

------
https://chatgpt.com/codex/tasks/task_e_684c0539c7048327848f4eec36880186