### PR TITLE
Add flatc availability check in make rule

### DIFF
--- a/mk/flatbuffer.mk
+++ b/mk/flatbuffer.mk
@@ -23,8 +23,12 @@ generate_footer:
 	  echo "❌ '$(FBS_DIR)/footer.fbs' not found."; exit 1; \
 	fi
 
-	@echo "📦 Generating FlatBuffers C++ (footer + datatype)…"
-	@mkdir -p "$(FBS_OUT)"
+        @echo "📦 Generating FlatBuffers C++ (footer + datatype)…"
+        @command -v flatc >/dev/null || { \
+            echo "❌ 'flatc' not found. Please install the FlatBuffers compiler."; \
+            exit 1; \
+        }
+        @mkdir -p "$(FBS_OUT)"
 	@flatc --cpp \
 	       --gen-object-api \
 	       --scoped-enums \


### PR DESCRIPTION
## Summary
- ensure `flatc` is present before generating footer code

## Testing
- `make format-check` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0535c9c8832787a9a28c62ebadcb