### PR TITLE
Add cross-platform example runners

### DIFF
--- a/mk/example.mk
+++ b/mk/example.mk
@@ -5,6 +5,7 @@ EXAMPLES_MK_INCLUDED := yes
 # Common helpers & C++ rules
 # ─────────────────────────────────────────────────────────────
 include $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/preamble.mk
+include $(abspath $(dir $(lastword $(MAKEFILE_LIST))))/cpp.mk
 
 # ─────────────────────────────────────────────────────────────
 # Compute paths relative to this file’s directory
@@ -31,6 +32,16 @@ CXX ?= c++
 EXE_EXT :=
 ifeq ($(OS),Windows_NT)
   EXE_EXT := .exe
+endif
+
+# Runtime library path for running examples
+RUN_ENV :=
+ifeq ($(OS),Windows_NT)
+  RUN_ENV := PATH=$(PREFIX)/bin;$(PATH)
+else ifeq ($(shell uname -s),Darwin)
+  RUN_ENV := DYLD_LIBRARY_PATH=$(PREFIX)/lib:$(DYLD_LIBRARY_PATH)
+else
+  RUN_ENV := LD_LIBRARY_PATH=$(PREFIX)/lib:$(LD_LIBRARY_PATH)
 endif
 
 # ─────────────────────────────────────────────────────────────
@@ -65,7 +76,7 @@ run-cpp-example: install-cpp
 	$(CXX) $(EXAMPLES_DIR)/cpp_example.cpp -I$(PREFIX)/include \
 	       -L$(PREFIX)/lib -lFastLanes -o $(EXAMPLES_DIR)/cpp_example$(EXE_EXT)
 	@echo "Running C++ example…"
-	$(EXAMPLES_DIR)/cpp_example$(EXE_EXT)
+	$(RUN_ENV) $(EXAMPLES_DIR)/cpp_example$(EXE_EXT)
 
 # ─────────────────────────────────────────────────────────────
 # Build & run the C API example
@@ -76,7 +87,7 @@ run-c-api-example: install-cpp
 	$(CC) $(EXAMPLES_DIR)/c_api.c -I$(PREFIX)/include \
 	       -L$(PREFIX)/lib -lFastLanes -o $(EXAMPLES_DIR)/c_api$(EXE_EXT)
 	@echo "Running C API example…"
-	$(EXAMPLES_DIR)/c_api$(EXE_EXT)
+	$(RUN_ENV) $(EXAMPLES_DIR)/c_api$(EXE_EXT)
 
 # ─────────────────────────────────────────────────────────────
 # Run the Python example (assumes the C++ lib is in PYTHONPATH)


### PR DESCRIPTION
## Summary
- include cpp.mk so example rules can leverage build and install targets
- set `RUN_ENV` to ensure executables find installed libraries
- prepend `RUN_ENV` when running C and C++ example targets

## Testing
- `make -f mk/example.mk -n run-cpp-example | head -n 20`
- `make -f mk/example.mk -n run-c-api-example | head -n 20`
- `cargo test --manifest-path rust/Cargo.toml` *(fails: terminated)*

------
https://chatgpt.com/codex/tasks/task_e_684c1acc115083278b4140f0580838cc