### PR TITLE
Add example build targets

### DIFF
--- a/mk/example.mk
+++ b/mk/example.mk
@@ -34,7 +34,10 @@ ifeq ($(OS),Windows_NT)
   EXE_EXT := .exe
 endif
 
-# Runtime library path for running examples
+# Runtime library path for running examples.
+# These settings ensure the FastLanes shared library is
+# discoverable across Linux, macOS and Windows when executing
+# the example binaries.
 RUN_ENV :=
 ifeq ($(OS),Windows_NT)
   RUN_ENV := PATH=$(PREFIX)/bin;$(PATH)
@@ -73,8 +76,8 @@ run-rust-example:
 # ─────────────────────────────────────────────────────────────
 run-cpp-example: install-cpp
 	@echo "Building C++ example…"
-	$(CXX) $(EXAMPLES_DIR)/cpp_example.cpp -I$(PREFIX)/include \
-	       -L$(PREFIX)/lib -lFastLanes -o $(EXAMPLES_DIR)/cpp_example$(EXE_EXT)
+	$(CXX) -std=c++20 $(EXAMPLES_DIR)/cpp_example.cpp -I$(PREFIX)/include \
+       -L$(PREFIX)/lib -lFastLanes -o $(EXAMPLES_DIR)/cpp_example$(EXE_EXT)
 	@echo "Running C++ example…"
 	$(RUN_ENV) $(EXAMPLES_DIR)/cpp_example$(EXE_EXT)
 
@@ -84,8 +87,8 @@ run-cpp-example: install-cpp
 # ─────────────────────────────────────────────────────────────
 run-c-api-example: install-cpp
 	@echo "Building C API example…"
-	$(CC) $(EXAMPLES_DIR)/c_api.c -I$(PREFIX)/include \
-	       -L$(PREFIX)/lib -lFastLanes -o $(EXAMPLES_DIR)/c_api$(EXE_EXT)
+	$(CC) -std=c11 $(EXAMPLES_DIR)/c_api.c -I$(PREFIX)/include \
+       -L$(PREFIX)/lib -lFastLanes -o $(EXAMPLES_DIR)/c_api$(EXE_EXT)
 	@echo "Running C API example…"
 	$(RUN_ENV) $(EXAMPLES_DIR)/c_api$(EXE_EXT)
 


### PR DESCRIPTION
## Summary
- compile and run a C++20 example with the installed library
- compile and run a C API example with the installed library
- note how the runtime environment is set up for Windows, macOS and Linux

## Testing
- `make -f mk/example.mk run-cpp-example --dry-run | tail -n 5`
- `make -f mk/example.mk run-c-api-example --dry-run | tail -n 5`


------
https://chatgpt.com/codex/tasks/task_e_684c318620e08327b855bb80ba95cdb7