### PR TITLE
Add standalone QuickFuzz test

### DIFF
--- a/.github/workflows/quick-fuzz.yml
+++ b/.github/workflows/quick-fuzz.yml
@@ -1,0 +1,39 @@
+name: Quick Fuzz
+run-name: >-
+  ${{ github.workflow }} on ${{ github.ref_name }} (#${{ github.run_number }}) — ${{ github.event.pull_request.title || github.event.head_commit.message }}
+
+on:
+  push:
+  pull_request:
+    branches: [ "main", "dev" ]
+
+env:
+  CMAKE_GENERATOR: Ninja
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect CPU count
+        run: make detect-cpu | tee -a "$GITHUB_ENV"
+
+      - name: Install LLVM
+        uses: ./.github/actions/install-llvm
+
+      - name: Configure
+        run: |
+          cmake -S "${{ github.workspace }}" \
+                -B build \
+                -DFLS_ENABLE_VERBOSE_OUTPUT=ON \
+                -DCMAKE_C_COMPILER=clang \
+                -DCMAKE_CXX_COMPILER=clang++ \
+                -DFLS_BUILD_TESTING=ON
+
+      - name: Build quick_fuzz_test
+        run: cmake --build build -j $BUILD_THREADS --target quick_fuzz_test
+
+      - name: Run QuickFuzz test
+        working-directory: build
+        run: ctest -R QuickFuzz --output-on-failure

--- a/.github/workflows/quick-fuzz.yml
+++ b/.github/workflows/quick-fuzz.yml
@@ -1,39 +1,60 @@
-name: Quick Fuzz
+name: Quick‑Fuzz CI
 run-name: >-
   ${{ github.workflow }} on ${{ github.ref_name }} (#${{ github.run_number }}) — ${{ github.event.pull_request.title || github.event.head_commit.message }}
 
 on:
   push:
+    branches: [ '**' ]
   pull_request:
-    branches: [ "main", "dev" ]
-
-env:
-  CMAKE_GENERATOR: Ninja
+    branches: [ main ]
+    paths:
+      - '**/*.cpp'
+      - 'test/src/quick_fuzz_tests/fuzz_config.json'
+      - '.github/workflows/fuzz.yml'
 
 jobs:
-  build:
+  build-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect CPU count
-        run: make detect-cpu | tee -a "$GITHUB_ENV"
-
-      - name: Install LLVM
-        uses: ./.github/actions/install-llvm
+      - name: Install build deps
+        run: sudo apt-get update && sudo apt-get install -y clang cmake ninja-build jq
 
       - name: Configure
+        run: cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Test
+        run: ctest --test-dir build --output-on-failure | tee ctest.log
+
+      # Collect fuzz artefacts & logs on failure
+      - name: Upload failure artefacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: quick-fuzz-failure-${{ github.run_id }}
+          path: |
+            tmp/fls_quick_fuzz/**
+            ctest.log
+
+      # Bump base_seed on any successful push
+      - name: Bump base_seed
+        if: success()
         run: |
-          cmake -S "${{ github.workspace }}" \
-                -B build \
-                -DFLS_ENABLE_VERBOSE_OUTPUT=ON \
-                -DCMAKE_C_COMPILER=clang \
-                -DCMAKE_CXX_COMPILER=clang++ \
-                -DFLS_BUILD_TESTING=ON
+          CONFIG=test/src/quick_fuzz_tests/fuzz_config.json
+          BASE=$(jq '.base_seed' "$CONFIG")
+          NEXT=$((BASE + 1))
+          echo "NEXT=$NEXT" >> $GITHUB_ENV
+          jq --argjson seed $NEXT '.base_seed = $seed' "$CONFIG" > "$CONFIG.tmp" && mv "$CONFIG.tmp" "$CONFIG"
 
-      - name: Build quick_fuzz_test
-        run: cmake --build build -j $BUILD_THREADS --target quick_fuzz_test
-
-      - name: Run QuickFuzz test
-        working-directory: build
-        run: ctest -R QuickFuzz --output-on-failure
+      - name: Commit updated fuzz_config.json
+        if: success()
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'CI: bump quick‑fuzz base_seed to ${{ env.NEXT }} [skip ci]'
+          branch: ${{ github.ref_name }}
+          commit_user_name: CI Bot
+          commit_user_email: ci@users.noreply.github.com

--- a/test/src/CMakeLists.txt
+++ b/test/src/CMakeLists.txt
@@ -2,5 +2,6 @@ add_subdirectory(dataset_tests)
 add_subdirectory(expression_tests)
 add_subdirectory(fls_reader_tests)
 add_subdirectory(primitive_tests)
+add_subdirectory(quick_fuzz_tests)
 add_subdirectory(unit_tests)
 

--- a/test/src/quick_fuzz_tests/CMakeLists.txt
+++ b/test/src/quick_fuzz_tests/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_executable(quick_fuzz_test
+    quick_fuzz_test.cpp
+)
+
+target_link_libraries(quick_fuzz_test
+    PRIVATE
+    gtest_main
+    FastLanes
+)
+
+fls_enable_sanitizers(quick_fuzz_test)
+
+gtest_discover_tests(
+    quick_fuzz_test
+    DISCOVERY_TIMEOUT 120
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)

--- a/test/src/quick_fuzz_tests/fuzz_config.json
+++ b/test/src/quick_fuzz_tests/fuzz_config.json
@@ -1,0 +1,5 @@
+{
+  "num_cases": 10,
+  "base_seed": 42,
+  "delimiter": "|"
+}

--- a/test/src/quick_fuzz_tests/fuzz_config.json
+++ b/test/src/quick_fuzz_tests/fuzz_config.json
@@ -1,5 +1,5 @@
 {
   "num_cases": 10,
-  "base_seed": 42,
+  "base_seed": 43,
   "delimiter": "|"
 }

--- a/test/src/quick_fuzz_tests/quick_fuzz_test.cpp
+++ b/test/src/quick_fuzz_tests/quick_fuzz_test.cpp
@@ -1,97 +1,179 @@
-#include "fls/csv/csv-parser/parser.hpp"
 #include "fls/connection.hpp"
+#include "fls/csv/csv-parser/parser.hpp"
 #include "fls/json/nlohmann/json.hpp"
 #include "fls/std/filesystem.hpp"
+#include <fstream>
 #include <gtest/gtest.h>
+#include <iostream>
 #include <random>
 #include <sstream>
 #include <string>
-#include <fstream>
+#include <vector>
 
 namespace fastlanes {
 
-// Generate a random CSV row with a fixed delimiter ',' and newline terminator.
-static std::string random_csv_row(std::mt19937 &rng, int columns) {
-    std::uniform_int_distribution<int> len_dist(0, 8);
-    std::uniform_int_distribution<char> char_dist('a', 'z');
+// ------------------------------------------------------------------
+// Configuration: load fuzz parameters from JSON at
+//   <repo>/test/src/quick_fuzz_tests/fuzz_config.json
+// ------------------------------------------------------------------
+namespace cfg {
+struct Settings {
+	int  num_cases = 10;
+	int  base_seed = 42;
+	char delim     = '|';
+};
 
-    std::string row;
-    for (int c = 0; c < columns; ++c) {
-        if (c > 0) row.push_back(',');
-        int len = len_dist(rng);
-        for (int i = 0; i < len; ++i) {
-            row.push_back(char_dist(rng));
-        }
-    }
-    row.push_back('\n');
-    return row;
+static Settings load() {
+	Settings s;
+	using fs::path;
+	try {
+		path config_path = path(FLS_CMAKE_SOURCE_DIR) / "test" / "src" / "quick_fuzz_tests" / "fuzz_config.json";
+		std::ifstream in(config_path);
+		if (in) {
+			nlohmann::json j;
+			in >> j;
+			if (j.contains("num_cases")) {
+				s.num_cases = j["num_cases"].get<int>();
+			}
+			if (j.contains("base_seed")) {
+				s.base_seed = j["base_seed"].get<int>();
+			}
+			if (j.contains("delimiter")) {
+				string d = j["delimiter"].get<string>();
+				if (!d.empty()) {
+					s.delim = d[0];
+				}
+			}
+		} else {
+			std::cerr << "[cfg] Warning: cannot open " << config_path << "; using defaults.\n";
+		}
+	} catch (const std::exception& ex) {
+		std::cerr << "[cfg] Error reading fuzz_config.json: " << ex.what() << "; using defaults.\n";
+	}
+	return s;
+}
+} // namespace cfg
+
+// ------------------------------------------------------------------
+// Core routine: build CSV + schema, round-trip through FastLanes.
+// Uses mixed types: integer or string, with occasional NULL.
+// Each case in its own directory under tmp.
+// ------------------------------------------------------------------
+static bool run_roundtrip(int seed, int case_idx, char delim) {
+	using fs::path;
+	std::mt19937                       rng(seed);
+	std::uniform_int_distribution<int> col_dist(1, 6);
+	// Ensure at least 1 character so no empty string fields
+	std::uniform_int_distribution<int> len_dist(1, 8);
+	std::uniform_int_distribution<int> char_dist('a', 'z');
+	std::uniform_int_distribution<int> int_dist(0, 1000);
+	std::uniform_int_distribution<int> null_dist(0, 9); // 10% nulls
+	const int                          cols = col_dist(rng);
+
+	// Determine column types
+	std::vector<bool>                  is_int(cols);
+	std::uniform_int_distribution<int> type_dist(0, 1);
+	for (int c = 0; c < cols; ++c) {
+		if (type_dist(rng) == 1) {
+			is_int[c] = true;
+		} else {
+			is_int[c] = false;
+		}
+	}
+
+	// Build schema JSON
+	nlohmann::json schema;
+	schema["columns"] = nlohmann::json::array();
+	for (int c = 0; c < cols; ++c) {
+		nlohmann::json col;
+		col["name"] = "col" + std::to_string(c);
+		col["type"] = is_int[c] ? "integer" : "string";
+		schema["columns"].push_back(col);
+	}
+
+	// Case-specific directory
+	path repo_root = path(FLS_CMAKE_SOURCE_DIR);
+	path case_dir  = repo_root / "tmp" / "fls_quick_fuzz" / ("case_" + std::to_string(case_idx));
+	fs::remove_all(case_dir);
+	fs::create_directories(case_dir);
+
+	// File paths
+	path csv_path    = case_dir / "generated.csv";
+	path schema_path = case_dir / "schema.json";
+	path fls_path    = case_dir / "data.fls";
+
+	// Write schema
+	{
+		std::ofstream out(schema_path);
+		out << schema.dump(2);
+	}
+
+	// Write CSV and capture first row for preview
+	string first_row;
+	{
+		std::ofstream out(csv_path);
+		for (int iter = 0; iter < 100; ++iter) {
+			std::ostringstream row_ss;
+			for (int c = 0; c < cols; ++c) {
+				if (c > 0) {
+					row_ss << delim;
+				}
+				if (is_int[c]) {
+					if (null_dist(rng) == 0) {
+						row_ss << "NULL";
+					} else {
+						row_ss << int_dist(rng);
+					}
+				} else {
+					int len = len_dist(rng);
+					for (int i = 0; i < len; ++i) {
+						row_ss << static_cast<char>(char_dist(rng));
+					}
+				}
+			}
+			row_ss << '\n';
+			string row = row_ss.str();
+			if (iter == 0) {
+				first_row = row;
+			}
+			out << row;
+		}
+	}
+
+	// Optional preview of case 0
+	if (case_idx == 0) {
+		std::cout << "==== Case 0 Preview ====" << std::endl;
+		std::cout << "Schema (cols=" << cols << "):\n" << schema.dump(2) << std::endl;
+		std::cout << "First CSV line (delim '" << delim << "'):\n" << first_row << std::endl;
+	}
+
+	// Encode and decode
+	Connection con1;
+	con1.set_n_vectors_per_rowgroup(1).read_csv(case_dir).to_fls(fls_path);
+	const auto& original_table = con1.get_table();
+
+	Connection con2;
+	auto       fls_reader    = con2.reset().read_fls(fls_path);
+	auto       decoded_table = fls_reader->materialize();
+
+	bool equal = (original_table == *decoded_table).is_equal;
+	return equal;
 }
 
-TEST(QuickFuzz, RandomCSVParsing) {
-    std::mt19937 rng(42);
-    std::uniform_int_distribution<int> col_dist(1, 6);
+// ------------------------------------------------------------------
+// GTest: runs the configured number of deterministic fuzz cases.
+// ------------------------------------------------------------------
+TEST(QuickFuzz, RandomRoundTripsWithConfig) {
+	const cfg::Settings s      = cfg::load();
+	bool                all_ok = true;
+	for (int i = 0; i < s.num_cases; ++i) {
+		all_ok &= run_roundtrip(s.base_seed + i, i, s.delim);
+	}
+	EXPECT_TRUE(all_ok);
 
-    // Generate a fixed column count for this run
-    int cols = col_dist(rng);
-
-    std::string csv_data;
-    for (int iter = 0; iter < 100; ++iter) {
-        std::string row = random_csv_row(rng, cols);
-        csv_data += row;
-
-        std::istringstream csv_stream(row);
-        aria::csv::CsvParser parser =
-            aria::csv::CsvParser(csv_stream).delimiter(',').terminator('\n');
-
-        for (auto &fields : parser) {
-            EXPECT_EQ(fields.size(), static_cast<size_t>(cols));
-        }
-    }
-
-    // ------------------------------------------------------------------
-    // Write CSV and schema to a temporary directory
-    // ------------------------------------------------------------------
-    using fastlanes::fs::path;
-    path temp_dir = fs::temp_directory_path() / "fls_quick_fuzz";
-    fs::create_directories(temp_dir);
-
-    path csv_path = temp_dir / "generated.csv";
-    {
-        std::ofstream out(csv_path);
-        out << csv_data;
-    }
-
-    nlohmann::json schema;
-    schema["columns"] = nlohmann::json::array();
-    for (int c = 0; c < cols; ++c) {
-        nlohmann::json col;
-        col["name"] = "col" + std::to_string(c);
-        col["type"] = "string";
-        schema["columns"].push_back(col);
-    }
-    path schema_path = temp_dir / "schema.json";
-    {
-        std::ofstream out(schema_path);
-        out << schema.dump(2);
-    }
-
-    // ------------------------------------------------------------------
-    // Encode to FastLanes and verify round trip
-    // ------------------------------------------------------------------
-    path fls_path = temp_dir / "data.fls";
-    Connection con1;
-    con1.set_n_vectors_per_rowgroup(1).read_csv(temp_dir).to_fls(fls_path);
-    const auto &original_table = con1.get_table();
-
-    Connection con2;
-    auto fls_reader = con2.reset().read_fls(fls_path);
-    auto decoded_table = fls_reader->materialize();
-
-    auto result = (original_table == *decoded_table);
-    EXPECT_TRUE(result.is_equal);
-
-    fs::remove_all(temp_dir);
+	// Cleanup entire fuzz tmp dir
+	using fs::path;
+	fs::remove_all(path(FLS_CMAKE_SOURCE_DIR) / "tmp" / "fls_quick_fuzz");
 }
 
 } // namespace fastlanes
-

--- a/test/src/quick_fuzz_tests/quick_fuzz_test.cpp
+++ b/test/src/quick_fuzz_tests/quick_fuzz_test.cpp
@@ -1,0 +1,97 @@
+#include "fls/csv/csv-parser/parser.hpp"
+#include "fls/connection.hpp"
+#include "fls/json/nlohmann/json.hpp"
+#include "fls/std/filesystem.hpp"
+#include <gtest/gtest.h>
+#include <random>
+#include <sstream>
+#include <string>
+#include <fstream>
+
+namespace fastlanes {
+
+// Generate a random CSV row with a fixed delimiter ',' and newline terminator.
+static std::string random_csv_row(std::mt19937 &rng, int columns) {
+    std::uniform_int_distribution<int> len_dist(0, 8);
+    std::uniform_int_distribution<char> char_dist('a', 'z');
+
+    std::string row;
+    for (int c = 0; c < columns; ++c) {
+        if (c > 0) row.push_back(',');
+        int len = len_dist(rng);
+        for (int i = 0; i < len; ++i) {
+            row.push_back(char_dist(rng));
+        }
+    }
+    row.push_back('\n');
+    return row;
+}
+
+TEST(QuickFuzz, RandomCSVParsing) {
+    std::mt19937 rng(42);
+    std::uniform_int_distribution<int> col_dist(1, 6);
+
+    // Generate a fixed column count for this run
+    int cols = col_dist(rng);
+
+    std::string csv_data;
+    for (int iter = 0; iter < 100; ++iter) {
+        std::string row = random_csv_row(rng, cols);
+        csv_data += row;
+
+        std::istringstream csv_stream(row);
+        aria::csv::CsvParser parser =
+            aria::csv::CsvParser(csv_stream).delimiter(',').terminator('\n');
+
+        for (auto &fields : parser) {
+            EXPECT_EQ(fields.size(), static_cast<size_t>(cols));
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Write CSV and schema to a temporary directory
+    // ------------------------------------------------------------------
+    using fastlanes::fs::path;
+    path temp_dir = fs::temp_directory_path() / "fls_quick_fuzz";
+    fs::create_directories(temp_dir);
+
+    path csv_path = temp_dir / "generated.csv";
+    {
+        std::ofstream out(csv_path);
+        out << csv_data;
+    }
+
+    nlohmann::json schema;
+    schema["columns"] = nlohmann::json::array();
+    for (int c = 0; c < cols; ++c) {
+        nlohmann::json col;
+        col["name"] = "col" + std::to_string(c);
+        col["type"] = "string";
+        schema["columns"].push_back(col);
+    }
+    path schema_path = temp_dir / "schema.json";
+    {
+        std::ofstream out(schema_path);
+        out << schema.dump(2);
+    }
+
+    // ------------------------------------------------------------------
+    // Encode to FastLanes and verify round trip
+    // ------------------------------------------------------------------
+    path fls_path = temp_dir / "data.fls";
+    Connection con1;
+    con1.set_n_vectors_per_rowgroup(1).read_csv(temp_dir).to_fls(fls_path);
+    const auto &original_table = con1.get_table();
+
+    Connection con2;
+    auto fls_reader = con2.reset().read_fls(fls_path);
+    auto decoded_table = fls_reader->materialize();
+
+    auto result = (original_table == *decoded_table);
+    EXPECT_TRUE(result.is_equal);
+
+    fs::remove_all(temp_dir);
+}
+
+} // namespace fastlanes
+


### PR DESCRIPTION
## Summary
- move QuickFuzz test to its own `quick_fuzz_tests` directory
- build new `quick_fuzz_test` target
- adjust workflow to build and run this target

## Testing
- `cmake -S . -B build -DFLS_BUILD_TESTING=ON`
- `cmake --build build -j $(nproc) --target quick_fuzz_test` *(fails: Interrupt)*
- `ctest --test-dir build -R QuickFuzz --output-on-failure` *(no tests were found)*


------
https://chatgpt.com/codex/tasks/task_e_6852a671fb98832785e57a410533be4c