### PR TITLE
Refactor benchmark helpers

### DIFF
--- a/benchmark/bench_compression_time.cpp
+++ b/benchmark/bench_compression_time.cpp
@@ -1,4 +1,5 @@
 #include "benchmarker.hpp"
+#include "benchmark_utils.hpp"
 
 using namespace fastlanes; // NOLINT
 
@@ -51,38 +52,18 @@ void bench_compression(dataset_view_t dataset_view) {
 	const std::string result_file_path =
 	    std::string(FLS_CMAKE_SOURCE_DIR) + "/benchmark/result/compression_time/public_bi/fastlanes.csv";
 
-	// Ensure the output directory exists
-	create_directories(std::filesystem::path(result_file_path).parent_path());
+        // Ensure the output directory exists
+        create_directories(std::filesystem::path(result_file_path).parent_path());
 
-	// Containers for results to be sorted later
-	std::vector<std::pair<std::string, double>> main_results;
+        const n_t n_repetition {1};
 
-	// Vector to store thread-specific directories for cleanup
-	const n_t n_repetition {1};
-
-	// Generate a thread-specific directory path
-	std::ostringstream thread_id_stream;
-	thread_id_stream << std::this_thread::get_id();
-	path thread_specific_fls_dir_path = fastlanes_repo_data_path / "data" / "fls" / thread_id_stream.str();
-
-	// Iterate over all tables in the dataset and process them in parallel
-	for (const auto& [table_name, file_path] : dataset_view) {
-
-		// Cleanup: Remove the thread-specific directory
-		clear_directory(thread_specific_fls_dir_path);
-		az_printer::green_cout << "-- Removed directory: " << thread_specific_fls_dir_path << std::endl;
-
-		CompressionTimeBenchmarker benchmarker {n_repetition};
-		auto compression_time_ms = benchmarker.bench_compression_time(file_path, thread_specific_fls_dir_path);
-
-		az_printer::green_cout << "-- Table " << table_name << " is benchmarked with time(ms): " << compression_time_ms
-		                       << std::endl;
-
-		main_results.emplace_back(table_name, compression_time_ms);
-	}
-
-	// Sort main results by table name
-	std::ranges::sort(main_results, [](const auto& a, const auto& b) { return a.first < b.first; });
+        auto main_results = run_dataset(dataset_view, [&](const std::string_view file_path, const path& dir) {
+                CompressionTimeBenchmarker benchmarker {n_repetition};
+                double ms = benchmarker.bench_compression_time(file_path, dir);
+                az_printer::green_cout << "-- Table " << file_path << " is benchmarked with time(ms): " << ms
+                                       << std::endl;
+                return ms;
+        });
 
 	// Compute the sum of compression times
 	double total_compression_time_ms = 0;

--- a/benchmark/bench_decompression_time.cpp
+++ b/benchmark/bench_decompression_time.cpp
@@ -1,4 +1,5 @@
 #include "benchmarker.hpp"
+#include "benchmark_utils.hpp"
 
 using namespace fastlanes; // NOLINT
 
@@ -37,38 +38,16 @@ void bench_decompression(dataset_view_t dataset_view) {
 	// Ensure the output directory exists
 	create_directories(std::filesystem::path(result_file_path).parent_path());
 
-	// Containers for results to be sorted later
-	std::vector<std::pair<std::string, double>> main_results;
+        const n_t n_repetition {1000};
 
-	// Vector to store thread-specific directories for cleanup
-	const n_t n_repetition {1000};
-
-	// Generate a thread-specific directory path
-	std::ostringstream thread_id_stream;
-	thread_id_stream << std::this_thread::get_id();
-	path thread_specific_fls_dir_path = fastlanes_repo_data_path / "data" / "fls" / thread_id_stream.str();
-
-	// Iterate over all tables in the dataset and process them in parallel
-	for (const auto& [table_name, file_path] : dataset_view) {
-		// Cleanup: Remove the thread-specific directory
-		clear_directory(thread_specific_fls_dir_path);
-
-		DecompressionTimeBenchmarker benchmarker {n_repetition};
-
-		benchmarker.Write(file_path, thread_specific_fls_dir_path);
-		auto        decompression_time_ms = benchmarker.bench(thread_specific_fls_dir_path);
-		const auto& footer_up             = benchmarker.GetTableDescriptor(thread_specific_fls_dir_path);
-
-		az_printer::green_cout << "-- Table " << table_name
-		                       << " is benchmarked with time(ms): " << decompression_time_ms << std::endl;
-
-		main_results.emplace_back(table_name, decompression_time_ms);
-
-		az_printer::green_cout << "-- Removed directory: " << thread_specific_fls_dir_path << std::endl;
-	}
-
-	// Sort main results by table name
-	std::ranges::sort(main_results, [](const auto& a, const auto& b) { return a.first < b.first; });
+        auto main_results = run_dataset(dataset_view, [&](const std::string_view file_path, const path& dir) {
+                DecompressionTimeBenchmarker benchmarker {n_repetition};
+                benchmarker.Write(file_path, dir);
+                double ms = benchmarker.bench(dir);
+                az_printer::green_cout << "-- Table " << file_path
+                                       << " is benchmarked with time(ms): " << ms << std::endl;
+                return ms;
+        });
 
 	// Compute the sum of decompression times
 	double total_decompression_time_ms = 0;

--- a/benchmark/bench_random_access.cpp
+++ b/benchmark/bench_random_access.cpp
@@ -1,4 +1,5 @@
 #include "benchmarker.hpp"
+#include "benchmark_utils.hpp"
 
 using namespace fastlanes; // NOLINT
 
@@ -34,38 +35,19 @@ void benchmark_random_access(dataset_view_t dataset_view) {
 	const std::string result_file_path =
 	    std::string(FLS_CMAKE_SOURCE_DIR) + "/benchmark/result/random_access/public_bi/fastlanes.csv";
 
-	// Ensure the output directory exists
-	create_directories(std::filesystem::path(result_file_path).parent_path());
+        // Ensure the output directory exists
+        create_directories(std::filesystem::path(result_file_path).parent_path());
 
-	// Containers for results to be sorted later
-	std::vector<std::pair<std::string, double>> main_results;
+        constexpr n_t n_repetition {1000};
 
-	constexpr n_t n_repetition {1000};
-
-	// Generate a thread-specific directory path
-	std::ostringstream thread_id_stream;
-	thread_id_stream << std::this_thread::get_id();
-	path thread_specific_fls_dir_path = fastlanes_repo_data_path / "data" / "fls" / thread_id_stream.str();
-
-	// Iterate over all tables in the dataset and process them in parallel
-	for (const auto& [table_name, file_path] : dataset_view) {
-		// Cleanup: Remove the thread-specific directory
-		clear_directory(thread_specific_fls_dir_path);
-
-		DecompressionTimeBenchmarker benchmarker {n_repetition};
-
-		benchmarker.Write(file_path, thread_specific_fls_dir_path);
-		auto        random_access_ms = benchmarker.bench_random_access(thread_specific_fls_dir_path);
-		const auto& footer_up        = benchmarker.GetTableDescriptor(thread_specific_fls_dir_path);
-
-		az_printer::green_cout << "-- Table " << table_name << " is benchmarked with time(ms): " << random_access_ms
-		                       << std::endl;
-
-		main_results.emplace_back(table_name, random_access_ms);
-	}
-
-	// Sort main results by table name
-	std::ranges::sort(main_results, [](const auto& a, const auto& b) { return a.first < b.first; });
+        auto main_results = run_dataset(dataset_view, [&](const std::string_view file_path, const path& dir) {
+                DecompressionTimeBenchmarker benchmarker {n_repetition};
+                benchmarker.Write(file_path, dir);
+                double random_access_ms = benchmarker.bench_random_access(dir);
+                az_printer::green_cout << "-- Table " << file_path << " is benchmarked with time(ms): " << random_access_ms
+                                       << std::endl;
+                return random_access_ms;
+        });
 
 	// Write results to the CSV files
 	std::ofstream csv_file(result_file_path);

--- a/benchmark/include/benchmark_utils.hpp
+++ b/benchmark/include/benchmark_utils.hpp
@@ -1,0 +1,37 @@
+#ifndef BENCHMARK_UTILS_HPP
+#define BENCHMARK_UTILS_HPP
+
+#include "benchmarker.hpp"
+#include <algorithm>
+#include <sstream>
+#include <vector>
+
+namespace fastlanes {
+
+inline path make_thread_specific_dir() {
+    std::ostringstream tid;
+    tid << std::this_thread::get_id();
+    return fastlanes_repo_data_path / "data" / "fls" / tid.str();
+}
+
+// Iterate over a dataset and run a benchmark function for each table.
+// The benchmark function should accept (string_view file_path, const path& dir)
+// and return a double representing the measured value.
+// Results are returned sorted by table name.
+template <typename BenchFunc>
+std::vector<std::pair<std::string, double>>
+run_dataset(dataset_view_t dataset_view, BenchFunc&& func) {
+    std::vector<std::pair<std::string, double>> results;
+    path dir = make_thread_specific_dir();
+    for (const auto& [table_name, file_path] : dataset_view) {
+        clear_directory(dir);
+        double v = func(file_path, dir);
+        results.emplace_back(std::string(table_name), v);
+    }
+    std::ranges::sort(results, [](const auto& a, const auto& b) { return a.first < b.first; });
+    return results;
+}
+
+} // namespace fastlanes
+
+#endif // BENCHMARK_UTILS_HPP

--- a/benchmark/micro_benchmark_decompression.cpp
+++ b/benchmark/micro_benchmark_decompression.cpp
@@ -1,4 +1,5 @@
 #include "benchmarker.hpp"
+#include "benchmark_utils.hpp"
 #include "cycle_counter.hpp"
 
 using namespace fastlanes; // NOLINT
@@ -42,15 +43,12 @@ void micro_benchmark_decompression(detailed_dataset_view_t dataset_view, const s
 	// Vector to store thread-specific directories for cleanup
 	const n_t n_repetition {1000};
 
-	// Generate a thread-specific directory path
-	std::ostringstream thread_id_stream;
-	thread_id_stream << std::this_thread::get_id();
-	path thread_specific_fls_dir_path = fastlanes_repo_data_path / "data" / "fls" / thread_id_stream.str();
+        // Generate a thread-specific directory path
+        path thread_specific_fls_dir_path = make_thread_specific_dir();
 
 	// Iterate over all tables in the dataset and process them in parallel
-	for (const auto& [table_name, file_path, idxs] : dataset_view) {
-		clear_directory(thread_specific_fls_dir_path);
-		az_printer::yellow_cout << "-- Removed directory: " << thread_specific_fls_dir_path << std::endl;
+        for (const auto& [table_name, file_path, idxs] : dataset_view) {
+                clear_directory(thread_specific_fls_dir_path);
 
 		DecompressionTimeBenchmarker benchmarker {n_repetition};
 


### PR DESCRIPTION
## Summary
- add `benchmark_utils.hpp` to share helper routines
- deduplicate benchmark code using `run_dataset` and `make_thread_specific_dir`
- clean up micro benchmark to use the helper

## Testing
- `cmake ..` *(fails: COMPILER_SUPPORTS_AVX512DQ)*
- `cmake --build .` *(fails: missing object file)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyfastlanes')*

------
https://chatgpt.com/codex/tasks/task_e_686ba8c2563c83279bfe2e273f0a4701