### PR TITLE
Add license header check workflow

### DIFF
--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -1,0 +1,24 @@
+name: License Header Check
+run-name: >-
+  ${{ github.workflow }} on ${{ github.ref_name }} (#${{ github.run_number }})
+  — ${{ github.event.pull_request.title || github.event.head_commit.message }}
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  license-header:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check license headers
+        run: python scripts/add_license_header.py --check
+


### PR DESCRIPTION
## Summary
- add a workflow to check license headers on pushes and PRs

## Testing
- `python scripts/add_license_header.py --check` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687f64e119d8832780ffb128997bf754