### PR TITLE
Switch ifstream to pread

### DIFF
--- a/src/include/fls/io/file.hpp
+++ b/src/include/fls/io/file.hpp
@@ -20,17 +20,20 @@ public:
 	explicit File(const path& path);
 	~File();
 
+	File(const File&)            = delete;
+	File& operator=(const File&) = delete;
+
 public:
 	// write to file_path
 	void Write(const Buf& buf);
 	// write to file_path
-	void Read(Buf& buf);
+	void Read(const Buf& buf) const;
 	// write to file_path
 	void Append(const Buf& buf);
 	// Append
 	void Append(const char* pointer, n_t size);
 	//
-	void ReadRange(Buf& buf, n_t offset, n_t size);
+	void ReadRange(const Buf& buf, n_t offset, n_t size) const;
 	// get file size
 	[[nodiscard]] n_t Size() const;
 
@@ -43,9 +46,13 @@ public:
 	static void append(const path& file_path, const string& dump);
 
 private:
+	void ReadInternal(uint8_t* dst, n_t size, off_t offset = 0) const;
+
+private:
 	path              m_path;
 	up<std::ofstream> m_of_stream;
-	up<std::ifstream> m_if_stream;
+	int               m_fd {-1};
+	size_t            m_file_size {0};
 };
 } // namespace fastlanes
 

--- a/src/include/fls/io/file.hpp
+++ b/src/include/fls/io/file.hpp
@@ -27,15 +27,15 @@ public:
 	// write to file_path
 	void Write(const Buf& buf);
 	// write to file_path
-	void Read(const Buf& buf) const;
+	void Read(const Buf& buf);
 	// write to file_path
 	void Append(const Buf& buf);
 	// Append
 	void Append(const char* pointer, n_t size);
 	//
-	void ReadRange(const Buf& buf, n_t offset, n_t size) const;
+	void ReadRange(const Buf& buf, n_t offset, n_t size);
 	// get file size
-	[[nodiscard]] n_t Size() const;
+	[[nodiscard]] n_t Size();
 
 public:
 	/// read from file_path and return string.
@@ -52,7 +52,7 @@ private:
 	path              m_path;
 	up<std::ofstream> m_of_stream;
 	int               m_fd {-1};
-	size_t            m_file_size {0};
+	off_t             m_file_size {-1};
 };
 } // namespace fastlanes
 

--- a/src/include/fls/std/filesystem.hpp
+++ b/src/include/fls/std/filesystem.hpp
@@ -19,7 +19,7 @@ public:
 	///! open read
 	static std::ifstream open_r(const path& file);
 	///! open read in binary
-	static std::ifstream open_r_binary(const path& file);
+	static int open_r_binary(const path& file);
 	///! open write
 	static std::ofstream open_w(const path& file);
 	///! open write in binary
@@ -29,9 +29,12 @@ public:
 	///! close
 	template <typename STREAM>
 	static void close(STREAM& stream);
+	static void close(int fd);
 	/// check if file system exist
 	static void check_if_dir_exists(const path& dir_path);
 	static void check_if_file_exists(const path& path);
+	/// read file size
+	static off_t read_file_size(int fd);
 };
 
 } // namespace fastlanes

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -19,6 +19,8 @@
 #include <unistd.h>   // for ::pread, ::close
 
 #if defined(__APPLE__)
+#include <sys/_types/_off_t.h>
+#include <sys/_types/_ssize_t.h>
 #include <sys/fcntl.h>
 #elif defined(__linux__)
 #include <fcntl.h>     // for ::open, O_RDONLY, O_CLOEXEC

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -36,7 +36,7 @@ File::File(const path& path) // NOLINT
 	}
 	m_fd = fd;
 
-	struct stat st{};
+	struct stat st {};
 	if (::fstat(fd, &st) != 0) {
 		::close(fd);
 		FLS_ABORT("Could not stat file in read-only mode")

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -15,7 +15,6 @@
 #include <ios>     // for std::ios, std::streamoff, std::streamsize
 #include <memory>  // for std::make_unique
 #include <sstream>
-#include <sys/stat.h> // for fstat, struct stat
 #include <unistd.h>   // for ::pread, ::close
 
 #if defined(__APPLE__)

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -21,9 +21,7 @@
 #if defined(__APPLE__)
 #include <sys/_types/_off_t.h>
 #include <sys/_types/_ssize_t.h>
-#include <sys/fcntl.h>
 #elif defined(__linux__)
-#include <fcntl.h>     // for ::open, O_RDONLY, O_CLOEXEC
 #include <sys/types.h> // for ssize_t, off_t
 #endif
 
@@ -31,19 +29,6 @@ namespace fastlanes {
 
 File::File(const path& path) // NOLINT
     : m_path(path) {
-
-	const int fd = ::open(m_path.c_str(), O_RDONLY | O_CLOEXEC);
-	if (fd < 0) {
-		FLS_ABORT("Could not open file in read-only mode")
-	}
-	m_fd = fd;
-
-	struct stat st {};
-	if (::fstat(fd, &st) != 0) {
-		::close(fd);
-		FLS_ABORT("Could not stat file in read-only mode")
-	}
-	m_file_size = static_cast<n_t>(st.st_size);
 }
 
 File::~File() {
@@ -53,7 +38,7 @@ File::~File() {
 	}
 
 	if (m_fd >= 0) {
-		::close(m_fd);
+		FileSystem::close(m_fd);
 	}
 }
 
@@ -65,23 +50,38 @@ void File::Write(const Buf& buf) {
 	m_of_stream->write(reinterpret_cast<char*>(buf.data()), static_cast<int64_t>(buf.Size()));
 }
 
-void File::Read(const Buf& buf) const {
+void File::Read(const Buf& buf) {
+	if (m_fd == -1) {
+		m_fd = FileSystem::open_r_binary(m_path);
+	}
+	if (m_file_size == -1) {
+		m_file_size = FileSystem::read_file_size(m_fd);
+	}
+
 	FLS_ASSERT_LE(m_file_size, buf.Capacity());
 
-	uint8_t* dst = buf.mutable_data();
-	ReadInternal(dst, m_file_size);
+	ReadInternal(buf.mutable_data(), static_cast<n_t>(m_file_size));
 }
 
-void File::ReadRange(const Buf& buf, const n_t offset, const n_t size) const {
+void File::ReadRange(const Buf& buf, const n_t offset, const n_t size) {
+	if (m_fd == -1) {
+		m_fd = FileSystem::open_r_binary(m_path);
+	}
+	if (m_file_size == -1) {
+		m_file_size = FileSystem::read_file_size(m_fd);
+	}
+
 	FLS_ASSERT_LE(offset + size, m_file_size);
 	FLS_ASSERT_LE(size, buf.Capacity());
 
-	uint8_t* dst = buf.mutable_data();
-	ReadInternal(dst, size, static_cast<off_t>(offset));
+	ReadInternal(buf.mutable_data(), size, static_cast<off_t>(offset));
 }
 
-n_t File::Size() const {
-	return m_file_size;
+n_t File::Size() {
+	if (m_file_size == -1) {
+		m_file_size = FileSystem::read_file_size(m_fd);
+	}
+	return static_cast<n_t>(m_file_size);
 }
 
 void File::Append(const Buf& buf) {

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -9,15 +9,16 @@
 #include "fls/cor/lyt/buf.hpp"
 #include "fls/std/filesystem.hpp"
 #include "fls/std/string.hpp"
-#include <cstdint>    // for int64_t
-#include <filesystem> // for std::filesystem::file_size, std::filesystem::exists
-#include <fstream>    // for std::ifstream, std::ofstream
-#include <ios>        // for std::ios, std::streamoff, std::streamsize
-#include <memory>     // for std::make_unique
+#include <cerrno>  // for errno, EINTR
+#include <cstdint> // for int64_t
+#include <fcntl.h> // for ::open, O_RDONLY, O_CLOEXEC
+#include <fstream> // for std::ifstream, std::ofstream
+#include <ios>     // for std::ios, std::streamoff, std::streamsize
+#include <memory>  // for std::make_unique
 #include <sstream>
-#include <sys/fcntl.h>
-#include <sys/stat.h>
-#include <unistd.h> // for pread
+#include <sys/stat.h>  // for fstat, struct stat
+#include <sys/types.h> // for ssize_t, off_t
+#include <unistd.h>    // for ::pread, ::close
 
 namespace fastlanes {
 

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -15,12 +15,27 @@
 #include <ios>        // for std::ios, std::streamoff, std::streamsize
 #include <memory>     // for std::make_unique
 #include <sstream>
-#include <stdexcept> // for std::runtime_error
+#include <sys/fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h> // for pread
 
 namespace fastlanes {
 
 File::File(const path& path) // NOLINT
     : m_path(path) {
+
+	const int fd = ::open(m_path.c_str(), O_RDONLY | O_CLOEXEC);
+	if (fd < 0) {
+		FLS_ABORT("Could not open file in read-only mode")
+	}
+	m_fd = fd;
+
+	struct stat st;
+	if (::fstat(fd, &st) != 0) {
+		::close(fd);
+		FLS_ABORT("Could not stat file in read-only mode")
+	}
+	m_file_size = static_cast<n_t>(st.st_size);
 }
 
 File::~File() {
@@ -29,8 +44,8 @@ File::~File() {
 		FileSystem::close(*m_of_stream);
 	}
 
-	if (m_if_stream != nullptr) {
-		FileSystem::close(*m_if_stream);
+	if (m_fd >= 0) {
+		::close(m_fd);
 	}
 }
 
@@ -42,35 +57,23 @@ void File::Write(const Buf& buf) {
 	m_of_stream->write(reinterpret_cast<char*>(buf.data()), static_cast<int64_t>(buf.Size()));
 }
 
-void File::Read(Buf& buf) {
-	if (m_if_stream == nullptr) {
-		m_if_stream = make_unique<std::ifstream>(FileSystem::open_r_binary(m_path));
-	}
+void File::Read(const Buf& buf) const {
+	FLS_ASSERT_LE(m_file_size, buf.Capacity());
 
-	auto file_size = fs::file_size(m_path);
-	FLS_ASSERT_LE(file_size, buf.Capacity())
-
-	m_if_stream->read(reinterpret_cast<char*>(buf.mutable_data()), static_cast<int64_t>(file_size));
+	uint8_t* dst = buf.mutable_data();
+	ReadInternal(dst, m_file_size);
 }
 
-void File::ReadRange(Buf& buf, const n_t offset, const n_t size) {
-	if (m_if_stream == nullptr) {
-		m_if_stream = make_unique<std::ifstream>(FileSystem::open_r_binary(m_path));
-	}
-
-	[[maybe_unused]] auto file_size = fs::file_size(m_path);
-	FLS_ASSERT_LE(offset + size, file_size);
+void File::ReadRange(const Buf& buf, const n_t offset, const n_t size) const {
+	FLS_ASSERT_LE(offset + size, m_file_size);
 	FLS_ASSERT_LE(size, buf.Capacity());
 
-	m_if_stream->seekg(static_cast<std::streamoff>(offset), std::ios::beg);
-	m_if_stream->read(reinterpret_cast<char*>(buf.mutable_data()), static_cast<std::streamsize>(size));
+	uint8_t* dst = buf.mutable_data();
+	ReadInternal(dst, size, static_cast<off_t>(offset));
 }
 
 n_t File::Size() const {
-	if (!exists(m_path)) {
-		throw std::runtime_error("File does not exist");
-	}
-	return static_cast<n_t>(std::filesystem::file_size(m_path));
+	return m_file_size;
 }
 
 void File::Append(const Buf& buf) {
@@ -87,6 +90,21 @@ void File::Append(const char* pointer, n_t size) {
 		m_of_stream = std::make_unique<std::ofstream>(m_path, std::ios::binary | std::ios::app);
 	}
 	m_of_stream->write(pointer, static_cast<int64_t>(size));
+}
+
+void File::ReadInternal(uint8_t* dst, const n_t size, const off_t offset) const {
+	n_t done = 0;
+	while (done < size) {
+		const ssize_t n_bytes = ::pread(m_fd, dst + done, size - done, offset + static_cast<off_t>(done));
+		if (n_bytes < 0 && errno == EINTR) {
+			continue;
+		}
+		if (n_bytes <= 0) {
+			FLS_ABORT("Could not read from file in read-only mode")
+		}
+
+		done += static_cast<n_t>(n_bytes);
+	}
 }
 
 /*--------------------------------------------------------------------------------------------------------------------*\

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -11,14 +11,19 @@
 #include "fls/std/string.hpp"
 #include <cerrno>  // for errno, EINTR
 #include <cstdint> // for int64_t
-#include <fcntl.h> // for ::open, O_RDONLY, O_CLOEXEC
 #include <fstream> // for std::ifstream, std::ofstream
 #include <ios>     // for std::ios, std::streamoff, std::streamsize
 #include <memory>  // for std::make_unique
 #include <sstream>
-#include <sys/stat.h>  // for fstat, struct stat
+#include <sys/stat.h> // for fstat, struct stat
+#include <unistd.h>   // for ::pread, ::close
+
+#if defined(__APPLE__)
+#include <sys/fcntl.h>
+#elif defined(__linux__)
+#include <fcntl.h>     // for ::open, O_RDONLY, O_CLOEXEC
 #include <sys/types.h> // for ssize_t, off_t
-#include <unistd.h>    // for ::pread, ::close
+#endif
 
 namespace fastlanes {
 
@@ -31,7 +36,7 @@ File::File(const path& path) // NOLINT
 	}
 	m_fd = fd;
 
-	struct stat st;
+	struct stat st{};
 	if (::fstat(fd, &st) != 0) {
 		::close(fd);
 		FLS_ABORT("Could not stat file in read-only mode")

--- a/src/io/file.cpp
+++ b/src/io/file.cpp
@@ -15,7 +15,7 @@
 #include <ios>     // for std::ios, std::streamoff, std::streamsize
 #include <memory>  // for std::make_unique
 #include <sstream>
-#include <unistd.h>   // for ::pread, ::close
+#include <unistd.h> // for ::pread, ::close
 
 #if defined(__APPLE__)
 #include <sys/_types/_off_t.h>

--- a/src/std/filesystem.cpp
+++ b/src/std/filesystem.cpp
@@ -4,12 +4,22 @@
 // src/std/filesystem.cpp
 // ────────────────────────────────────────────────────────
 #include "fls/std/filesystem.hpp"
+#include "fls/common/assert.hpp"
 #include <cerrno>     // errno
 #include <filesystem> // std::filesystem::path, exists, is_directory, is_regular_file
 #include <fstream>
-#include <ios>          // std::ios::binary
-#include <stdexcept>    // std::runtime_error
+#include <ios>       // std::ios::binary
+#include <stdexcept> // std::runtime_error
+#include <sys/stat.h>
 #include <system_error> // NEW – std::system_error / std::error_code
+#include <unistd.h>     // for ::close
+
+#if defined(__APPLE__)
+#include <sys/_types/_off_t.h>
+#include <sys/fcntl.h>
+#elif defined(__linux__)
+#include <fcntl.h>
+#endif
 
 namespace fastlanes {
 
@@ -29,12 +39,12 @@ std::ifstream FileSystem::open_r(const path& file) {
 	return stream;
 }
 
-std::ifstream FileSystem::open_r_binary(const path& file) {
-	std::ifstream stream(file.c_str(), std::ios::binary);
-	if (!stream) {
-		throw_last_error(file);
+int FileSystem::open_r_binary(const path& file) {
+	const int fd = ::open(file.c_str(), O_RDONLY | O_CLOEXEC);
+	if (fd < 0) {
+		FLS_ABORT("Could not open file in read-only mode")
 	}
-	return stream;
+	return fd;
 }
 
 std::ofstream FileSystem::open_w(const path& file) {
@@ -74,9 +84,22 @@ void FileSystem::check_if_file_exists(const fs::path& file_path) {
 	}
 }
 
+off_t FileSystem::read_file_size(const int fd) {
+	struct stat st {};
+	if (::fstat(fd, &st) != 0) {
+		FileSystem::close(fd);
+		FLS_ABORT("Could not stat file in read-only mode")
+	}
+	return st.st_size;
+}
+
 template <typename STREAM>
 void FileSystem::close(STREAM& stream) {
 	stream.close();
+}
+
+void FileSystem::close(const int fd) {
+	::close(fd);
 }
 
 template void FileSystem::close(std::ifstream&);

--- a/src/std/filesystem.cpp
+++ b/src/std/filesystem.cpp
@@ -19,6 +19,7 @@
 #include <sys/fcntl.h>
 #elif defined(__linux__)
 #include <fcntl.h>
+#include <sys/types.h> // off_t
 #endif
 
 namespace fastlanes {

--- a/test/src/quick_fuzz_tests/fuzz_config.json
+++ b/test/src/quick_fuzz_tests/fuzz_config.json
@@ -1,6 +1,6 @@
 {
   "num_cases": 10,
-  "base_seed": 11,
+  "base_seed": 12,
   "delimiter": "|",
   "min_cols": 1,
   "max_cols": 2,


### PR DESCRIPTION
Changed the current `ifstream` implementation for File I/O to `pread` system calls to reduce overhead. Further changed the way the file size is fetched, using `fstat` in favor of `fs::file_size` as we can already use the existing file descriptor from `pread`. The file size is stored in the `File` class so that no further syscalls are required on subsequent size requests.

Another benefit of `pread` is that it is thread-safe, making it possible to hoist the multiple `File` instances into a single instance in the `TableReader` behind the `io` interface (not done in this PR).

This implementation does not support Windows, as it there is no `pread` available.